### PR TITLE
(SERVER-1774) Add 4 digit release plugin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,4 +36,6 @@
   ;; you should take care to exclude the things that you don't want
   ;; in your final jar.  Here is an example of how you could exclude
   ;; that from the final uberjar:
-  :uberjar-exclusions  [#"META-INF/jruby.home/lib/ruby/shared/org/bouncycastle"])
+  :uberjar-exclusions  [#"META-INF/jruby.home/lib/ruby/shared/org/bouncycastle"]
+
+  :plugins [[lein-release-4digit-version "0.2.0"]])


### PR DESCRIPTION
Add the 4 digit release plugin since jruby-deps uses a qualifier to track
versions. This will let CI bump the right value when it gets released