### PR TITLE
(SERVER-1774) Use the 4 digit release plugin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                                      :password :env/clojars_jenkins_password
                                      :sign-releases false}]]
 
-  :plugins [[lein-release-4digit-version "0.1.0"]]
+  :plugins [[lein-release-4digit-version "0.2.0"]]
 
   :uberjar-name "jruby-9k.jar"
 


### PR DESCRIPTION
Since jruby-deps 9.x uses a 4 digit version number and a qualifier to track
versions. This will let CI bump the qualifier when it gets released