### PR TITLE
(SERVER-1803) Exclude org.ow2.asm deps from uberjar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,7 @@
+(def jruby-version "1.7.26")
+(def jffi-version "1.2.12")
+(def jnr-x86asm-version "1.0.2")
+
 (defproject puppetlabs/jruby-deps "1.7.26-2-SNAPSHOT"
   :description "JRuby dependencies"
   :url "https://github.com/puppetlabs/jruby-deps"
@@ -8,23 +12,71 @@
 
   :pedantic? :abort
 
-  :dependencies [[org.jruby/jruby-core "1.7.26"
-                  :exclusions  [com.github.jnr/jffi
-                                com.github.jnr/jnr-x86asm
-                                joda-time
-                                org.yaml/snakeyaml]]
+  ;; Note that there is a fair amount of duplication between the
+  ;; dependencies listed in this section and the ones in the corresponding
+  ;; section under the uberjar profile.  If you make any changes here,
+  ;; check the uberjar dependencies to see if the change should be repeated
+  ;; there.
+  :dependencies [[org.jruby/jruby-core ~jruby-version
+                  :exclusions [com.github.jnr/jffi
+                               com.github.jnr/jnr-x86asm
+                               org.ow2.asm/asm
+                               org.ow2.asm/asm-analysis
+                               org.ow2.asm/asm-commons
+                               org.ow2.asm/asm-tree
+                               org.ow2.asm/asm-util]]
+
+                 ;; jruby-core has dependencies on discrete org.ow2.asm
+                 ;; artifacts whereas other common Clojure projects like
+                 ;; core.async declare a dependency on org.ow2.asm/asm-all,
+                 ;; which provides a superset of the content of the
+                 ;; discrete org.ow2.asm dependencies.  Defining asm-all
+                 ;; here to allows for conflict resolution to be possible
+                 ;; in consuming projects.
+                 [org.ow2.asm/asm-all "5.0.3"]
+
                  ;; jffi and jnr-x86asm are explicit dependencies because,
                  ;; in JRuby's poms, they are defined using version ranges,
                  ;; and :pedantic? :abort won't tolerate this.
-                 [com.github.jnr/jffi "1.2.12"]
-                 [com.github.jnr/jffi "1.2.12" :classifier "native"]
-                 [com.github.jnr/jnr-x86asm "1.0.2"]
-                 [org.jruby/jruby-stdlib "1.7.26"]]
+                 [com.github.jnr/jffi ~jffi-version]
+                 [com.github.jnr/jffi ~jffi-version :classifier "native"]
+                 [com.github.jnr/jnr-x86asm ~jnr-x86asm-version]
+                 [org.jruby/jruby-stdlib ~jruby-version]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
                                      :password :env/clojars_jenkins_password
                                      :sign-releases false}]]
+
+  :profiles {:uberjar
+             ;; Dependencies from the project are largely repeated in the
+             ;; uberjar dependencies, with the exception that dependencies
+             ;; which are commonly used in other jar files which would be used
+             ;; with jruby-deps are omitted.  This avoids conflicts which might
+             ;; otherwise arise when multiple classpath entries on the Java
+             ;; command line provide different versions of the same dependencies.
+             ;;
+             ;; Jars which are used in conjunction with jruby-deps should
+             ;; provide their own versions of the following:
+             ;;
+             ;; [joda-time]
+             ;; [org.ow2.asm/asm-all]
+             ;; [org.yaml/snakeyaml]
+             {:dependencies ^:replace
+              [[org.jruby/jruby-core ~jruby-version
+                :exclusions [com.github.jnr/jffi
+                             com.github.jnr/jnr-x86asm
+                             joda-time
+                             org.ow2.asm/asm
+                             org.ow2.asm/asm-analysis
+                             org.ow2.asm/asm-commons
+                             org.ow2.asm/asm-tree
+                             org.ow2.asm/asm-util
+                             org.yaml/snakeyaml]]
+               [com.github.jnr/jffi ~jffi-version]
+               [com.github.jnr/jffi ~jffi-version :classifier "native"]
+               [com.github.jnr/jnr-x86asm ~jnr-x86asm-version]
+               [org.jruby/jruby-stdlib ~jruby-version]]}}
 
   :uberjar-name "jruby-1_7.jar"
 
@@ -32,8 +84,5 @@
   ;; of its jar.  e.g., it puts a pre-built copy of the bouncycastle
   ;; jar into its META-INF directory.  This is highly undesirable
   ;; for projects that already have a dependency on a different
-  ;; version of bouncycastle.  Therefore, when building uberjars,
-  ;; you should take care to exclude the things that you don't want
-  ;; in your final jar.  Here is an example of how you could exclude
-  ;; that from the final uberjar:
+  ;; version of bouncycastle.  Items below are excluded from the uberjar.
   :uberjar-exclusions  [#"META-INF/jruby.home/lib/ruby/shared/org/bouncycastle"])

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,70 @@
 (def jruby-version "1.7.26")
 (def jffi-version "1.2.12")
-(def jnr-x86asm-version "1.0.2")
+
+(def base-dependencies
+  "Base set of dependencies which are built into the project's artifact.
+  Note that these dependencies are customized somewhat when building an
+  uberjar.  See the `uberjar-dependencies` variable."
+  [['org.jruby/jruby-core jruby-version
+    :exclusions ['com.github.jnr/jffi
+                 'com.github.jnr/jnr-x86asm
+                 'org.ow2.asm/asm
+                 'org.ow2.asm/asm-analysis
+                 'org.ow2.asm/asm-commons
+                 'org.ow2.asm/asm-tree
+                 'org.ow2.asm/asm-util]]
+
+   ;; jruby-core has dependencies on discrete org.ow2.asm artifacts whereas
+   ;; other common Clojure projects like core.async declare a dependency on
+   ;; org.ow2.asm/asm-all, which provides a superset of the content of the
+   ;; discrete org.ow2.asm dependencies.  Defining asm-all here allows for
+   ;; conflict resolution to be possible in consuming projects.
+   ['org.ow2.asm/asm-all "5.0.3"]
+
+   ;; jffi and jnr-x86asm are explicit dependencies because, in JRuby's poms,
+   ;; they are defined using version ranges, and :pedantic? :abort won't
+   ;; tolerate this.
+   ['com.github.jnr/jffi jffi-version]
+   ['com.github.jnr/jffi jffi-version :classifier "native"]
+   ['com.github.jnr/jnr-x86asm "1.0.2"]
+   ['org.jruby/jruby-stdlib jruby-version]])
+
+;; For the jruby-deps uberjar builds, we want to exclude a few dependencies
+;; which we expect to be provided by other jars in the Java classpath.  We
+;; do this in order to make the dependency resolution predictable regardless
+;; of the order in which the jars are referenced on the classpath.  The
+;; following variables list the dependencies which are excluded from the
+;; default ones listed in the `base-dependencies` variable above.
+
+(def extra-top-level-dependency-exclusions-from-uberjar
+  "Set of dependencies which are excluded from the top-level ones in
+  `base-dependencies` when building an uberjar.  For example, if
+  `base-dependencies` were to include [['a] ['b] ['c] ['d]] and the set returned
+  from this variable were #{'b 'c}, the top-level dependencies built into the
+  uberjar would be [['a] ['d]]."
+  #{'org.ow2.asm/asm-all})
+
+(def extra-jruby-core-exclusions-from-uberjar
+  "Set of dependencies which are added to exclusions from jruby-core in
+  `base-dependencies` when building an uberjar.  For example, if the jruby-core
+  dependency were excluding ['a 'b] in `base-dependencies` and the set
+  returned from this variable were #{'c 'd}, the complete list of dependencies
+  which would be excluded from the jruby-core dependency would be
+  ['a 'b 'c 'd]."
+  #{'joda-time
+    'org.yaml/snakeyaml})
+
+(def uberjar-dependencies
+  "Customize the list of dependencies from `base-dependencies` for use in
+  building an uberjar."
+  (->> base-dependencies
+    (remove #(contains? extra-top-level-dependency-exclusions-from-uberjar
+               (first %)))
+    (map #(if (= 'org.jruby/jruby-core (first %))
+            (update % (dec (count %))
+              (fn [exclusions]
+                (concat exclusions extra-jruby-core-exclusions-from-uberjar)))
+            (identity %)))))
 
 (defproject puppetlabs/jruby-deps "1.7.26-2-SNAPSHOT"
   :description "JRuby dependencies"
@@ -12,71 +76,16 @@
 
   :pedantic? :abort
 
-  ;; Note that there is a fair amount of duplication between the
-  ;; dependencies listed in this section and the ones in the corresponding
-  ;; section under the uberjar profile.  If you make any changes here,
-  ;; check the uberjar dependencies to see if the change should be repeated
-  ;; there.
-  :dependencies [[org.jruby/jruby-core ~jruby-version
-                  :exclusions [com.github.jnr/jffi
-                               com.github.jnr/jnr-x86asm
-                               org.ow2.asm/asm
-                               org.ow2.asm/asm-analysis
-                               org.ow2.asm/asm-commons
-                               org.ow2.asm/asm-tree
-                               org.ow2.asm/asm-util]]
-
-                 ;; jruby-core has dependencies on discrete org.ow2.asm
-                 ;; artifacts whereas other common Clojure projects like
-                 ;; core.async declare a dependency on org.ow2.asm/asm-all,
-                 ;; which provides a superset of the content of the
-                 ;; discrete org.ow2.asm dependencies.  Defining asm-all
-                 ;; here to allows for conflict resolution to be possible
-                 ;; in consuming projects.
-                 [org.ow2.asm/asm-all "5.0.3"]
-
-                 ;; jffi and jnr-x86asm are explicit dependencies because,
-                 ;; in JRuby's poms, they are defined using version ranges,
-                 ;; and :pedantic? :abort won't tolerate this.
-                 [com.github.jnr/jffi ~jffi-version]
-                 [com.github.jnr/jffi ~jffi-version :classifier "native"]
-                 [com.github.jnr/jnr-x86asm ~jnr-x86asm-version]
-                 [org.jruby/jruby-stdlib ~jruby-version]]
+  :dependencies ~base-dependencies
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
                                      :password :env/clojars_jenkins_password
                                      :sign-releases false}]]
 
-  :profiles {:uberjar
-             ;; Dependencies from the project are largely repeated in the
-             ;; uberjar dependencies, with the exception that dependencies
-             ;; which are commonly used in other jar files which would be used
-             ;; with jruby-deps are omitted.  This avoids conflicts which might
-             ;; otherwise arise when multiple classpath entries on the Java
-             ;; command line provide different versions of the same dependencies.
-             ;;
-             ;; Jars which are used in conjunction with jruby-deps should
-             ;; provide their own versions of the following:
-             ;;
-             ;; [joda-time]
-             ;; [org.ow2.asm/asm-all]
-             ;; [org.yaml/snakeyaml]
-             {:dependencies ^:replace
-              [[org.jruby/jruby-core ~jruby-version
-                :exclusions [com.github.jnr/jffi
-                             com.github.jnr/jnr-x86asm
-                             joda-time
-                             org.ow2.asm/asm
-                             org.ow2.asm/asm-analysis
-                             org.ow2.asm/asm-commons
-                             org.ow2.asm/asm-tree
-                             org.ow2.asm/asm-util
-                             org.yaml/snakeyaml]]
-               [com.github.jnr/jffi ~jffi-version]
-               [com.github.jnr/jffi ~jffi-version :classifier "native"]
-               [com.github.jnr/jnr-x86asm ~jnr-x86asm-version]
-               [org.jruby/jruby-stdlib ~jruby-version]]}}
+  :profiles {:uberjar {:dependencies ~(with-meta
+                                        uberjar-dependencies
+                                        {:replace true})}}
 
   :uberjar-name "jruby-1_7.jar"
 
@@ -85,4 +94,4 @@
   ;; jar into its META-INF directory.  This is highly undesirable
   ;; for projects that already have a dependency on a different
   ;; version of bouncycastle.  Items below are excluded from the uberjar.
-  :uberjar-exclusions  [#"META-INF/jruby.home/lib/ruby/shared/org/bouncycastle"])
+  :uberjar-exclusions [#"META-INF/jruby.home/lib/ruby/shared/org/bouncycastle"])

--- a/project.clj
+++ b/project.clj
@@ -1,26 +1,20 @@
 (def jruby-version "1.7.26")
 (def jffi-version "1.2.12")
 
-(def base-dependencies
-  "Base set of dependencies which are built into the project's artifact.
-  Note that these dependencies are customized somewhat when building an
-  uberjar.  See the `uberjar-dependencies` variable."
+(defn deps-with-jruby-core-exclusions
+  "Return a vector of the project's dependency coordinates with any arguments
+  supplied being appended as exclusions from the org.jruby/jruby-core
+  dependency."
+  [& extra-jruby-core-exclusions]
   [['org.jruby/jruby-core jruby-version
-    :exclusions ['com.github.jnr/jffi
-                 'com.github.jnr/jnr-x86asm
-                 'org.ow2.asm/asm
-                 'org.ow2.asm/asm-analysis
-                 'org.ow2.asm/asm-commons
-                 'org.ow2.asm/asm-tree
-                 'org.ow2.asm/asm-util]]
-
-   ;; jruby-core has dependencies on discrete org.ow2.asm artifacts whereas
-   ;; other common Clojure projects like core.async declare a dependency on
-   ;; org.ow2.asm/asm-all, which provides a superset of the content of the
-   ;; discrete org.ow2.asm dependencies.  Defining asm-all here allows for
-   ;; conflict resolution to be possible in consuming projects.
-   ['org.ow2.asm/asm-all "5.0.3"]
-
+    :exclusions (concat ['com.github.jnr/jffi
+                         'com.github.jnr/jnr-x86asm
+                         'org.ow2.asm/asm
+                         'org.ow2.asm/asm-analysis
+                         'org.ow2.asm/asm-commons
+                         'org.ow2.asm/asm-tree
+                         'org.ow2.asm/asm-util]
+                  extra-jruby-core-exclusions)]
    ;; jffi and jnr-x86asm are explicit dependencies because, in JRuby's poms,
    ;; they are defined using version ranges, and :pedantic? :abort won't
    ;; tolerate this.
@@ -28,43 +22,6 @@
    ['com.github.jnr/jffi jffi-version :classifier "native"]
    ['com.github.jnr/jnr-x86asm "1.0.2"]
    ['org.jruby/jruby-stdlib jruby-version]])
-
-;; For the jruby-deps uberjar builds, we want to exclude a few dependencies
-;; which we expect to be provided by other jars in the Java classpath.  We
-;; do this in order to make the dependency resolution predictable regardless
-;; of the order in which the jars are referenced on the classpath.  The
-;; following variables list the dependencies which are excluded from the
-;; default ones listed in the `base-dependencies` variable above.
-
-(def extra-top-level-dependency-exclusions-from-uberjar
-  "Set of dependencies which are excluded from the top-level ones in
-  `base-dependencies` when building an uberjar.  For example, if
-  `base-dependencies` were to include [['a] ['b] ['c] ['d]] and the set returned
-  from this variable were #{'b 'c}, the top-level dependencies built into the
-  uberjar would be [['a] ['d]]."
-  #{'org.ow2.asm/asm-all})
-
-(def extra-jruby-core-exclusions-from-uberjar
-  "Set of dependencies which are added to exclusions from jruby-core in
-  `base-dependencies` when building an uberjar.  For example, if the jruby-core
-  dependency were excluding ['a 'b] in `base-dependencies` and the set
-  returned from this variable were #{'c 'd}, the complete list of dependencies
-  which would be excluded from the jruby-core dependency would be
-  ['a 'b 'c 'd]."
-  #{'joda-time
-    'org.yaml/snakeyaml})
-
-(def uberjar-dependencies
-  "Customize the list of dependencies from `base-dependencies` for use in
-  building an uberjar."
-  (->> base-dependencies
-    (remove #(contains? extra-top-level-dependency-exclusions-from-uberjar
-               (first %)))
-    (map #(if (= 'org.jruby/jruby-core (first %))
-            (update % (dec (count %))
-              (fn [exclusions]
-                (concat exclusions extra-jruby-core-exclusions-from-uberjar)))
-            (identity %)))))
 
 (defproject puppetlabs/jruby-deps "1.7.26-2-SNAPSHOT"
   :description "JRuby dependencies"
@@ -76,15 +33,32 @@
 
   :pedantic? :abort
 
-  :dependencies ~base-dependencies
+  :dependencies ~(conj
+                   (deps-with-jruby-core-exclusions)
+                   ;; jruby-core has dependencies on discrete org.ow2.asm
+                   ;; artifacts whereas other common Clojure projects like
+                   ;; core.async declare a dependency on org.ow2.asm/asm-all,
+                   ;; which provides a superset of the content of the discrete
+                   ;; org.ow2.asm dependencies. Defining asm-all here allows
+                   ;; for conflict resolution to be possible in consuming
+                   ;; projects.
+                   ['org.ow2.asm/asm-all "5.0.3"])
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
                                      :password :env/clojars_jenkins_password
                                      :sign-releases false}]]
 
+  ;; For the jruby-deps uberjar builds, we want to exclude a few "common"
+  ;; dependencies  which we expect to be provided by other jars in the Java
+  ;; classpath. We do this in order to make the dependency resolution
+  ;; predictable regardless of the order in which the jars are referenced on the
+  ;; classpath. Dependencies in the uberjar profile replace those from the base
+  ;; project definition in order to exclude the unwanted dependencies from the
+  ;; jruby-deps uberjar.
   :profiles {:uberjar {:dependencies ~(with-meta
-                                        uberjar-dependencies
+                                        (deps-with-jruby-core-exclusions
+                                          'joda-time 'org.yaml/snakeyaml)
                                         {:replace true})}}
 
   :uberjar-name "jruby-1_7.jar"


### PR DESCRIPTION
Previously, jruby-core brought in discrete org.ow2.asm dependencies.
The versions of these dependencies conflict with the asm-all dependency
that Clojure's core.async uses.  When the jruby-deps uberjar were used
with other jars on the Java command line, the version of the asm
dependencies which would be used would depend on the order the jars
appear on the Java classpath.  In cases of conflicts between the two,
e.g., where a class might exist in one jar but not the other within the
same Java package, this could lead to problems where classes from
mismatched versions were errantly used together.

This commit changes the dependencies to export asm-all as an artifact
dependency rather than the discrete org.ow2.asm dependencies, to allow
for asm conflict resolution to be done at packaging time.  Also, all
of the asm dependencies are omitted from the uberjar profile so that
a jruby-deps uberjar doesn't run the risk of having asm content in it
which would conflict with the content in a paired jar used on the same
Java classpath.