### PR TITLE
Merge branch '1.7.x' into 9.x at 656ac11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,5 @@
+(def jruby-version "9.1.8.0")
+
 (defproject puppetlabs/jruby-deps "9.1.8.0-2-SNAPSHOT"
   :description "JRuby dependencies"
   :url "https://github.com/puppetlabs/jruby-deps"
@@ -8,8 +10,8 @@
 
   :pedantic? :abort
 
-  :dependencies [[org.jruby/jruby-core "9.1.8.0" :exclusions [joda-time]]
-                 [org.jruby/jruby-stdlib "9.1.8.0"]]
+  :dependencies [[org.jruby/jruby-core ~jruby-version]
+                 [org.jruby/jruby-stdlib ~jruby-version]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
@@ -18,15 +20,24 @@
 
   :plugins [[lein-release-4digit-version "0.2.0"]]
 
+  ;; For the jruby-deps uberjar builds, we want to exclude a few "common"
+  ;; dependencies which we expect to be provided by other jars in the Java
+  ;; classpath. We do this in order to make the dependency resolution
+  ;; predictable regardless of the order in which the jars are referenced on the
+  ;; classpath. Dependencies in the uberjar profile replace those from the base
+  ;; project definition in order to exclude the unwanted dependencies from the
+  ;; jruby-deps uberjar.
+  :profiles {:uberjar {:dependencies
+                       [[org.jruby/jruby-core ~jruby-version
+                         :exclusions [joda-time
+                                      org.yaml/snakeyaml]]]}}
+
   :uberjar-name "jruby-9k.jar"
 
   ;; NOTE: jruby-stdlib packages some unexpected things inside
   ;; of its jar.  e.g., it puts a pre-built copy of the bouncycastle
   ;; and snakeyaml jars into its META-INF directory.  This is highly
   ;; undesirable for projects that already have dependencies on different
-  ;; versions of these jars.  Therefore, when building uberjars,
-  ;; you should take care to exclude the things that you don't want
-  ;; in your final jar.  Here is an example of how you could exclude
-  ;; that from the final uberjar:
+  ;; versions of these jars.  Items below are excluded from the uberjar.
   :uberjar-exclusions  [#"META-INF/jruby.home/lib/ruby/stdlib/org/bouncycastle"
                         #"META-INF/jruby.home/lib/ruby/stdlib/org/yaml/snakeyaml"])


### PR DESCRIPTION
    * 1.7.x:
      Version 1.7.26-3-SNAPSHOT
      Version 1.7.26-2
      (SERVER-1803) Simplify base and uberjar dependency sharing
      (SERVER-1803) Reduce duplication between base and uberjar dependencies
      (SERVER-1803) Exclude org.ow2.asm deps from uberjar

    Conflicts:
     - project.clj: resolved conflicting dependencies from 1.7 in favor
        of more appropriate ones for 9k.