### PR TITLE
(SERVER-1815) Bump JRuby 9k deps to 9.1.9.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(def jruby-version "9.1.8.0")
+(def jruby-version "9.1.9.0")
 
-(defproject puppetlabs/jruby-deps "9.1.8.0-3-SNAPSHOT"
+(defproject puppetlabs/jruby-deps "9.1.9.0-1-SNAPSHOT"
   :description "JRuby dependencies"
   :url "https://github.com/puppetlabs/jruby-deps"
   :license {:name "Apache License, Version 2.0"
@@ -29,8 +29,7 @@
   ;; jruby-deps uberjar.
   :profiles {:uberjar {:dependencies
                        [[org.jruby/jruby-core ~jruby-version
-                         :exclusions [joda-time
-                                      org.yaml/snakeyaml]]]}}
+                         :exclusions [joda-time]]]}}
 
   :uberjar-name "jruby-9k.jar"
 


### PR DESCRIPTION
This commit bumps the JRuby 9k dependencies from 9.1.8.0 to 9.1.9.0.
The commit also removes an unnecessary exclusion of the snakeyaml
dependency in the uberjar profile.  snakeyaml is no longer a Maven-level
dependency in JRuby.