### PR TITLE
(SERVER-1821) Pin newer ffi versions for memory leak fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,13 @@
   :pedantic? :abort
 
   :dependencies [[org.jruby/jruby-core ~jruby-version]
+                 [com.github.jnr/jffi "1.2.16"]
+                 [com.github.jnr/jffi "1.2.16" :classifier "native"]
+                 [com.github.jnr/jnr-ffi "2.1.6" :exclusions [org.ow2.asm/asm-analysis
+                                                              org.ow2.asm/asm-commons
+                                                              org.ow2.asm/asm-tree
+                                                              org.ow2.asm/asm-util
+                                                              org.ow2.asm/asm]]
                  [org.jruby/jruby-stdlib ~jruby-version]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"


### PR DESCRIPTION
This commit pins jffi and jnr-ffi versions to newer releases, 1.2.16 and
2.1.6, which have a fix for native memory allocations.  See
https://github.com/jnr/jnr-ffi/issues/117.

We'd eventually like to just bump to a newer version of JRuby 9k which
bundles in the newer ffi deps but it appears that it may take a few weeks
before the community is able to do another JRuby release with these
changes and this is a severe enough defect that it seems worthwhile to
try to get it rolled up into Puppet Server before the Puppet 5 release. 