### PR TITLE
(SERVER-1840) Bump JRuby 9k deps to 9.1.11.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(def jruby-version "9.1.9.0")
+(def jruby-version "9.1.11.0")
 
-(defproject puppetlabs/jruby-deps "9.1.9.0-3-SNAPSHOT"
+(defproject puppetlabs/jruby-deps "9.1.11.0-1-SNAPSHOT"
   :description "JRuby dependencies"
   :url "https://github.com/puppetlabs/jruby-deps"
   :license {:name "Apache License, Version 2.0"
@@ -11,13 +11,6 @@
   :pedantic? :abort
 
   :dependencies [[org.jruby/jruby-core ~jruby-version]
-                 [com.github.jnr/jffi "1.2.16"]
-                 [com.github.jnr/jffi "1.2.16" :classifier "native"]
-                 [com.github.jnr/jnr-ffi "2.1.6" :exclusions [org.ow2.asm/asm-analysis
-                                                              org.ow2.asm/asm-commons
-                                                              org.ow2.asm/asm-tree
-                                                              org.ow2.asm/asm-util
-                                                              org.ow2.asm/asm]]
                  [org.jruby/jruby-stdlib ~jruby-version]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"


### PR DESCRIPTION
This commit bumps the jruby-core and jruby-stdlib deps to 9.1.11.0.
This commit also eliminates the previous pins for the jffi and jnr-jffi
deps since the latest versions of those have been rolled up into JRuby
9.1.11.0.