### PR TITLE
(SERVER-1874) Update jruby dependency to 9.1.15.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(def jruby-version "9.1.11.0")
+(def jruby-version "9.1.15.0")
 
-(defproject puppetlabs/jruby-deps "9.1.11.0-2-SNAPSHOT"
+(defproject puppetlabs/jruby-deps "9.1.15.0-1-SNAPSHOT"
   :description "JRuby dependencies"
   :url "https://github.com/puppetlabs/jruby-deps"
   :license {:name "Apache License, Version 2.0"
@@ -10,7 +10,7 @@
 
   :pedantic? :abort
 
-  :dependencies [[org.jruby/jruby-core ~jruby-version]
+  :dependencies [[org.jruby/jruby-core ~jruby-version :exclusions [org.jruby.jcodings/jcodings]]
                  [org.jruby/jruby-stdlib ~jruby-version]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"


### PR DESCRIPTION
jruby and joni disagree about what version of jcodings to use. Hopefully
that is addressed in the next release of jruby.