### PR TITLE
(SERVER-1874) Explicitly add jcodings version to project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,8 @@
 
   :pedantic? :abort
 
-  :dependencies [[org.jruby/jruby-core ~jruby-version :exclusions [org.jruby.jcodings/jcodings]]
+  :dependencies [[org.jruby.jcodings/jcodings "1.0.18"]
+                 [org.jruby/jruby-core ~jruby-version :exclusions [org.jruby.jcodings/jcodings]]
                  [org.jruby/jruby-stdlib ~jruby-version]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"


### PR DESCRIPTION
A previous commit excluded jcodings to avoid a version conflict, but
this also caused it to be excluded from consumers of jruby-deps, which
resulted in jruby not having all of its symbols. This commit explicitly
adds the version that jruby-core expects to project.clj.