### PR TITLE
(maint) Update JRuby to 9.2.8.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(def jruby-version "9.2.7.0")
+(def jruby-version "9.2.8.0")
 
-(defproject puppetlabs/jruby-deps "9.2.7.0-2-SNAPSHOT"
+(defproject puppetlabs/jruby-deps "9.2.8.0-1-SNAPSHOT"
   :description "JRuby dependencies"
   :url "https://github.com/puppetlabs/jruby-deps"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
We might want to wait a week to see if there's any fall out from this release before upgrading.