### PR TITLE
(SERVER-2660) Update JRuby to 9.2.11.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jruby-version "9.2.11.0")
+(def jruby-version "9.2.11.1")
 
 (defproject puppetlabs/jruby-deps "9.2.11.0-2-SNAPSHOT"
   :description "JRuby dependencies"


### PR DESCRIPTION
This contains a bugfix for an sprintf buffer miscalculation.