### PR TITLE
update snyk scan to on push and v2 action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,28 +2,30 @@
 name: Clojure Snyk Check
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
  snyk_scan:
    runs-on: ubuntu-latest
-   if: contains(github.event.pull_request.labels.*.name, 'safe to test')
    steps:
+    - uses: twingate/github-action@v1
+      with:
+        service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
     - name: checkout the current PR
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         persist-credentials: false
     - name: Run Clojure Snyk Scan
       id: scan
-      uses: puppetlabs/security-snyk-clojure-action@main
+      uses: puppetlabs/security-snyk-clojure-action@v2
       with:
         snykToken: ${{ secrets.SNYK_PE_TOKEN }}
-        rproxyKey: ${{ secrets.SEC_PUBLIC_RPROXY_KEY }}
-        rproxyUser: ${{ secrets.SEC_PUBLIC_RPROXY_USER }}
-        snykOrg: 'puppet-foss'
-        snykProject: 'jruby-deps'
+        snykOrg: 'puppet-enterprise'
+        snykPolicy: '.snyk'
     - name: Check output
       if: steps.scan.outputs.vulns != ''
       run: echo "Vulnerabilities detected; ${{ steps.scan.outputs.vulns }}" && exit 1


### PR DESCRIPTION
This updates the snyk scanning to v2 of the action to use TwinGate vs the reverse proxy