### PR TITLE
Merge 9.x -> main

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def jruby-version "9.3.4.0")
 
-(defproject puppetlabs/jruby-deps "9.3.4.0-1-SNAPSHOT"
+(defproject puppetlabs/jruby-deps "9.3.4.0-2-SNAPSHOT"
   :description "JRuby dependencies"
   :url "https://github.com/puppetlabs/jruby-deps"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
We're going to delete the `9.x` branch, since we don't need both that and `main`.
This makes sure that `main` has all the latest changes (specifically jruby-utils is already using jruby-deps 9.3.4.0-1, so this will ensure that versions are bumped appropriately going forward).