### PR TITLE
Revert "(maint) Pin jnr-posix to 3.1.8"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,12 +11,7 @@
   :pedantic? :abort
 
   :dependencies [[org.jruby/jruby-core ~jruby-version]
-                 [org.jruby/jruby-stdlib ~jruby-version]
-
-                 ;; Works around CVE-2014-4043 in JRuby,
-                 ;; Unpin when we upgrade to at least JRuby 9.2.20
-                 [com.github.jnr/jnr-posix "3.1.8" :exclusions [com.github.jnr/jffi
-                                                                com.github.jnr/jnr-constants]]]
+                 [org.jruby/jruby-stdlib ~jruby-version]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username


### PR DESCRIPTION
This reverts commit 68add780f426d3f3c7011bcc0c2d666b487ec4a8.
JRuby 9.3.x does not include a vulnerable version of jnr-posix, so we can remove
this pin. This will also allow us to resolve a pedantic dependency conflict,
since jnr-posix 3.1.8 (via jnr-ffi 2.2.5) brought in an old version of asm.