### PR TITLE
(maint) Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,4 @@
-# This will cause the puppetserver-maintainers group to be assigned
-# review of any opened PRs against the branches containing this file.
+# This repo is owned by the PE teams
 
-* @puppetlabs/dumpling
-* @puppetlabs/skeletor
+* @puppetlabs/dumpling @puppetlabs/skeletor
 


### PR DESCRIPTION
This commit updates the CODEOWNERS file to put all teams on the same line. 
Previously, by having two separate lines with the `*` rule, the last-defined rule takes precedence and only the Skeletor team would be applied as owners. 
This also updates the comment to remove mention of the old owners.